### PR TITLE
fixed booking and paypal

### DIFF
--- a/app/controllers/bookings_controller.rb
+++ b/app/controllers/bookings_controller.rb
@@ -171,11 +171,12 @@ class BookingsController < ApplicationController
   # Paypal sends this
   protect_from_forgery except: [:hook]
   def hook
+    byebug
     params.permit! # Permit all Paypal input params
     status = params[:payment_status]
-
+    id = params[:invoice].scan(/\d+/).first
     if status == "Completed"
-      @booking = Booking.find params[:invoice]
+      @booking = Booking.find id
       guest = @booking.guest
       host = @booking.experience.host
       Guestmailer.payment_confirmed(guest.id, @booking.id).deliver_now

--- a/app/models/booking.rb
+++ b/app/models/booking.rb
@@ -53,17 +53,18 @@ class Booking < ActiveRecord::Base
 	def paypal_url(return_path)
 	@experience = Experience.find(self.experience_id)
 	values = {
-	    business: "hewrin-facilitator@hotmail.com ",
+	    business: "thenasiproject-facilitator@gmail.com ",
 	    cmd: "_xclick",
 	    upload: 1,
 	    return: "#{Rails.application.secrets.app_host}#{return_path}",
-	    invoice: id,
+	    invoice: "#{id}" + (0...8).map { (65 + rand(26)).chr }.join,
 	    amount: @experience.price,
 	    item_name: "#{@experience.title} experience booking",
 	    item_number: @experience.id,
 	    quantity: self.group_size,
 	    notify_url: "#{Rails.application.secrets.app_host}/hook"
 	}
+
 	"#{Rails.application.secrets.paypal_host}/cgi-bin/webscr?" + values.to_query
 	end
 end

--- a/app/views/bookings/_form.html.erb
+++ b/app/views/bookings/_form.html.erb
@@ -69,6 +69,8 @@
       class:"btn btn-warning " %>
     <% end %>
   </div>
+  <% elsif current_host == @experience.host && @action == "edit" %>
+     <%= f.submit submit_text, class:"btn btn-primary btn-sm" %>
   <% else %>
     <%= link_to "Sign In Here", new_guest_session_path, class:"btn btn-primary btn-sm" %>
   <% end %>

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -13,7 +13,7 @@
 development:
   secret_key_base: ad31cfa08c3e0f17f196fb8eb5c5c022861cfc50cbd8e27d3db433a0782771820b9a90bfd798e4aabbbb7ab6319e6b06ed44dd068af1b197400ac1cc5f3d1193
   paypal_host: https://www.sandbox.paypal.com
-  app_host: http://22064e80.ngrok.com
+  app_host: http://2328b995.ngrok.com
 
 test:
   secret_key_base: dcf7096801723002bab4e96f7b306a57c4272a5d585a026cabb54c7661bbb70c8a83500d1e1883be24bfebdd9c0ab6aa3183c081b8ffad72bcdb2b68d9465382


### PR DESCRIPTION
paypal was broken because the invoice number was set to booking id, which was already in the history of the paypal merchant, this caused a "Invoice already payed error" So added a random string to invoice number. 
